### PR TITLE
Add ability to use autotls option

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ class MailListener extends EventEmitter {
       host: options.host,
       port: options.port,
       tls: options.tls,
+      autotls: options.autotls || null,
       tlsOptions: options.tlsOptions || {},
       connTimeout: options.connTimeout || null,
       authTimeout: options.authTimeout || null,

--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,7 @@ var mailListener = new MailListener({
   connTimeout: 10000, // Default by node-imap
   authTimeout: 5000, // Default by node-imap,
   debug: console.log, // Or your custom function with only one incoming argument. Default: null
+  autotls: 'never', // default by node-imap
   tlsOptions: { rejectUnauthorized: false },
   mailbox: "INBOX", // mailbox to monitor
   searchFilter: ["ALL"], // the search filter being used after an IDLE notification has been retrieved


### PR DESCRIPTION
Adds the ability to use node-imap's autotls option which is useful for servers that require starttls.

From the node-imap package documentation:

autotls - string - Set to 'always' to always attempt connection upgrades via STARTTLS, 'required' only if upgrading is required, or 'never' to never attempt upgrading. Default: 'never'